### PR TITLE
Better concurrency to prevent overlaps

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -14,20 +15,21 @@ import (
 
 // DataStorer is the interface that wraps methods to store monitoring data.
 type DataStorer interface {
-    StoreWebsiteStatus(website string, status string, latency time.Duration) error
+    StoreWebsiteStatus(website string, statusCode int, latency time.Duration) error
 }
 
 type Monitor struct {
 	ds DataStorer
 	es mail.EmailSender
 	isRunning bool
+	cancelFunc context.CancelFunc
 	
 	websites []string
 	interval time.Duration
 	downAlertThreshold int
 	alertEmails []string
 
-	statusHistory map[string][]string
+	statusHistory map[string][]int
 	latencyHistory map[string][]time.Duration
 }
 
@@ -87,72 +89,100 @@ func NewMonitor(ds DataStorer, es mail.EmailSender) (*Monitor, error) {
 		alertEmails: alertEmails,
 
 		// State
-		statusHistory: make(map[string][]string),
+		statusHistory: make(map[string][]int),
 		latencyHistory: make(map[string][]time.Duration),
 	}, nil
 }
 
+// Start the monitoring goroutines for each website.
 func (m *Monitor) Start() {
 	fmt.Println(m.interval, m.websites)
     m.isRunning = true
-    for m.isRunning {
-        for _, website := range m.websites {
-			// Ping inside a goroutine to prevent blocking the loop
-            go func(website string) {
-                log.Println("Pinging website", website)
-                status, latency := m.pingWebsite(website)
 
-				m.appendStatusHistory(website, status)
+	ctx, cancel := context.WithCancel(context.Background())
+    m.cancelFunc = cancel // Store the cancel function to call it later
 
-				if m.shouldSendDownAlert(website) {
-					log.Println("Sending down alert for", website)
-					err := m.es.SendEmail(m.alertEmails, "Website down", website + " is down!")
-					if err != nil {
-						log.Println("Error sending down alert: ", err)
-					}
+	for _, website := range m.websites {
+		go func(website string) {
+			for {
+				select {
+				case <-ctx.Done():
+					log.Println("Stopping monitor for", website)
+					return
+				default:
+					m.tick(website)
 
-					// Reset the status history to prevent sending multiple alerts
-					m.statusHistory[website] = []string{}
+					time.Sleep(m.interval)
 				}
-
-				err := m.ds.StoreWebsiteStatus(website, status, latency)
-				if err != nil {
-					log.Println("Error storing website status: ", err)
-				}
-
-
-            }(website)
-        }
-        time.Sleep(m.interval)
-    }
+			}
+		}(website)
+	}
 }
 
+// Stop the monitoring goroutines for each website.
+// uses the cancel function to stop the goroutines.
 func (m *Monitor) Stop() {
-	if(m.isRunning) {
+	if(m.isRunning && m.cancelFunc != nil) {
+		// Call the cancel function to stop the goroutines
+		m.cancelFunc()
 		m.isRunning = false
 	}
 }
 
-func (m *Monitor) pingWebsite(website string) (status string, latency time.Duration) {
+// Handles the event inside the monitoring goroutine loop for a website.
+// Includes pinging the website, updating the status history, and sending alerts if necessary.
+func (m *Monitor) tick(website string) {
+	log.Println("Pinging website", website)
+	statusCode, latency := m.pingWebsite(website)
+
+	m.appendStatusHistory(website, statusCode)
+
+	err := m.ds.StoreWebsiteStatus(website, statusCode, latency)
+	if err != nil {
+		log.Println("Error storing website status: ", err)
+	}
+
+	if m.shouldSendDownAlert(website) {
+		log.Println("Sending down alert for", website)
+		err := m.es.SendEmail(m.alertEmails, "Website down", website + " is down!")
+		if err != nil {
+			log.Println("Error sending down alert: ", err)
+		}
+
+		// Reset the status history to prevent sending multiple alerts
+		m.statusHistory[website] = []int{}
+	}
+}
+
+// Pings a website and returns the status and latency.
+func (m *Monitor) pingWebsite(website string) (status int, latency time.Duration) {
+	log.Println("hit", website)
+
 	start := time.Now()
-	
+	var statusCode int
+
 	// Ping website
 	resp, err := http.Get(website)
 	latency = time.Since(start)
 
+	log.Println("Pinged", website, "in", latency)
 	if(err != nil) {
 		log.Println("Error pinging: ", err)
-
-		return "down", latency // Don't return the error as it's it's not important to the caller
+		statusCode = 0
+		return statusCode, latency
 	}
 	defer resp.Body.Close()
+	
+	// Get status code
+	statusCode = resp.StatusCode
 
-	return "up", latency
+	return statusCode, latency
 }
 
-func (m *Monitor) appendStatusHistory(website string, status string) {
+// Appends the status to the status history and removes the oldest entry if far enough out of bounds for the required logic.
+func (m *Monitor) appendStatusHistory(website string, statusCode int) {
 	// Update the status history
-	m.statusHistory[website] = append(m.statusHistory[website], status)
+	m.statusHistory[website] = append(m.statusHistory[website], statusCode)
 
 	// If the history is longer than the downAlertThreshold * 2, remove the oldest entry (no longer relevant)
 	if len(m.statusHistory[website]) > m.downAlertThreshold * 2 {
@@ -160,6 +190,7 @@ func (m *Monitor) appendStatusHistory(website string, status string) {
 	}
 }
 
+// Checks if the website has been down for the downAlertThreshold and should send an alert.
 func (m *Monitor) shouldSendDownAlert(website string) bool {
 	history := m.statusHistory[website]
 
@@ -167,11 +198,11 @@ func (m *Monitor) shouldSendDownAlert(website string) bool {
 		return false
 	}
 
-	for _, status := range history[len(history) - m.downAlertThreshold:] {
-		if status != "down" {
-			return false
+	for _, statusCode := range history[len(history) - m.downAlertThreshold:] {
+		if statusCode > 499 || statusCode == 0 { // 0 represents an error on the ping (e.g. if the website does not exist)
+			return true
 		}
 	}
 
-	return true
+	return false
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -57,12 +57,12 @@ func (s *SQLiteStorer) runMigrations() error {
     return nil
 }
 
-func (s *SQLiteStorer) StoreWebsiteStatus(website string, status string, latency time.Duration) error {
-	query := `INSERT INTO website_status (website, status, latency) VALUES (?, ?, ?)`
+func (s *SQLiteStorer) StoreWebsiteStatus(website string, statusCode int, latency time.Duration) error {
+	query := `INSERT INTO website_status (website, status_code, latency) VALUES (?, ?, ?)`
 	
 	latencyMs := latency.Milliseconds()
 
-	_, err := s.db.Exec(query, website, status, latencyMs)
+	_, err := s.db.Exec(query, website, statusCode, latencyMs)
 	if(err != nil) {
 		return err
 	}

--- a/migrations/0001_create_website_status_table.up.sql
+++ b/migrations/0001_create_website_status_table.up.sql
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS website_status (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     website TEXT NOT NULL,
-    status TEXT NOT NULL,
+    status_code INTEGER NOT NULL,
     latency INTEGER,
     checked_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
Make independent goroutines to prevent overlapping checks per website.
Replace status with statusCode so that the logic to determine if the website was up or down can be adjusted as needed (or even configured by the user)